### PR TITLE
fix the bug of duplicated email at paste

### DIFF
--- a/src/react-multi-email/ReactMultiEmail.tsx
+++ b/src/react-multi-email/ReactMultiEmail.tsx
@@ -62,7 +62,7 @@ class ReactMultiEmail extends React.Component<
     let inputValue: string = '';
     const re = /[ ,;]/g;
     const isEmail = validateEmail || isEmailFn;
-
+    
     const addEmails = (email: string) => {
       const emails: string[] = this.state.emails;
       for (let i = 0, l = emails.length; i < l; i++) {
@@ -76,12 +76,17 @@ class ReactMultiEmail extends React.Component<
 
     if (value !== '') {
       if (re.test(value)) {
-        let arr = value.split(re).filter(n => {
+        let splitData = value.split(re).filter(n => {
           return n !== '' && n !== undefined && n !== null;
         });
 
+        const setArr = new Set(splitData);
+        
+        let arr = [...setArr];
+
         do {
           if (isEmail('' + arr[0])) {
+            console.log(arr[0])
             addEmails('' + arr.shift());
           } else {
             if (arr.length === 1) {

--- a/src/react-multi-email/ReactMultiEmail.tsx
+++ b/src/react-multi-email/ReactMultiEmail.tsx
@@ -86,7 +86,6 @@ class ReactMultiEmail extends React.Component<
 
         do {
           if (isEmail('' + arr[0])) {
-            console.log(arr[0])
             addEmails('' + arr.shift());
           } else {
             if (arr.length === 1) {


### PR DESCRIPTION
a@naver.com a@naver.com 이런식으로 메모장에 적어 놓고 다시 email 란에 붙여 넣으면 a@naver.com 라는 이메일이 2개 나오는 버그를 수정 하였습니다. 확인 부탁드립니다. 마지막에 console.log 안지워서 다시 지웠습니다.