### PR TITLE
Fix the bug of duplicated email at paste

### DIFF
--- a/src/react-multi-email/ReactMultiEmail.tsx
+++ b/src/react-multi-email/ReactMultiEmail.tsx
@@ -76,9 +76,12 @@ class ReactMultiEmail extends React.Component<
 
     if (value !== '') {
       if (re.test(value)) {
-        let arr = value.split(re).filter(n => {
+        let splitData = value.split(re).filter(n => {
           return n !== '' && n !== undefined && n !== null;
         });
+        
+        const setArr = new Set(splitData);
+        let arr = [...setArr];
 
         do {
           if (isEmail('' + arr[0])) {


### PR DESCRIPTION
If duplicate email addresses were copied from Notepad and pasted to the ReactMultiEmail tag, duplicate addresses would appear. So I fix it.