### PR TITLE
Refactoring Class-based codes to Hook 

### DIFF
--- a/dist/commonjs/ReactMultiEmail.d.ts
+++ b/dist/commonjs/ReactMultiEmail.d.ts
@@ -15,28 +15,5 @@ export interface IReactMultiEmailState {
     emails: string[];
     inputValue?: string;
 }
-declare class ReactMultiEmail extends React.Component<IReactMultiEmailProps, IReactMultiEmailState> {
-    state: {
-        focused: boolean;
-        emails: any[];
-        inputValue: string;
-    };
-    emailInputRef: React.RefObject<HTMLInputElement>;
-    static getDerivedStateFromProps(nextProps: IReactMultiEmailProps, prevState: IReactMultiEmailState): {
-        propsEmails: string[];
-        emails: string[];
-        inputValue: string;
-        focused: boolean;
-    };
-    constructor(props: IReactMultiEmailProps);
-    findEmailAddress: (value: string, isEnter?: boolean) => void;
-    onChangeInputValue: (value: string) => void;
-    removeEmail: (index: number) => void;
-    handleOnKeydown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-    handleOnKeyup: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-    handleOnChange: (e: React.SyntheticEvent<HTMLInputElement>) => void;
-    handleOnBlur: (e: React.SyntheticEvent<HTMLInputElement>) => void;
-    handleOnFocus: () => void;
-    render(): JSX.Element;
-}
+declare const ReactMultiEmail: (props: IReactMultiEmailProps) => JSX.Element;
 export default ReactMultiEmail;

--- a/dist/commonjs/ReactMultiEmail.js
+++ b/dist/commonjs/ReactMultiEmail.js
@@ -1,137 +1,14 @@
 "use strict";
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
 var React = require("react");
+var react_1 = require("react");
 var isEmail_1 = require("./isEmail");
-var ReactMultiEmail = /** @class */ (function (_super) {
-    __extends(ReactMultiEmail, _super);
-    function ReactMultiEmail(props) {
-        var _this = _super.call(this, props) || this;
-        _this.state = {
-            focused: false,
-            emails: [],
-            inputValue: '',
-        };
-        _this.findEmailAddress = function (value, isEnter) {
-            var validateEmail = _this.props.validateEmail;
-            var validEmails = [];
-            var inputValue = '';
-            var re = /[ ,;]/g;
-            var isEmail = validateEmail || isEmail_1.default;
-            var addEmails = function (email) {
-                var emails = _this.state.emails;
-                for (var i = 0, l = emails.length; i < l; i++) {
-                    if (emails[i] === email) {
-                        return false;
-                    }
-                }
-                validEmails.push(email);
-                return true;
-            };
-            if (value !== '') {
-                if (re.test(value)) {
-                    var arr = value.split(re).filter(function (n) {
-                        return n !== '' && n !== undefined && n !== null;
-                    });
-                    do {
-                        if (isEmail('' + arr[0])) {
-                            addEmails('' + arr.shift());
-                        }
-                        else {
-                            if (arr.length === 1) {
-                                /// 마지막 아이템이면 inputValue로 남겨두기
-                                inputValue = '' + arr.shift();
-                            }
-                            else {
-                                arr.shift();
-                            }
-                        }
-                    } while (arr.length);
-                }
-                else {
-                    if (isEnter) {
-                        if (isEmail(value)) {
-                            addEmails(value);
-                        }
-                        else {
-                            inputValue = value;
-                        }
-                    }
-                    else {
-                        inputValue = value;
-                    }
-                }
-            }
-            _this.setState({
-                emails: _this.state.emails.concat(validEmails),
-                inputValue: inputValue,
-            });
-            if (validEmails.length && _this.props.onChange) {
-                _this.props.onChange(_this.state.emails.concat(validEmails));
-            }
-        };
-        _this.onChangeInputValue = function (value) {
-            _this.findEmailAddress(value);
-        };
-        _this.removeEmail = function (index) {
-            _this.setState(function (prevState) {
-                return {
-                    emails: prevState.emails.slice(0, index).concat(prevState.emails.slice(index + 1)),
-                };
-            }, function () {
-                if (_this.props.onChange) {
-                    _this.props.onChange(_this.state.emails);
-                }
-            });
-        };
-        _this.handleOnKeydown = function (e) {
-            switch (e.which) {
-                case 13:
-                case 9:
-                    e.preventDefault();
-                    break;
-                case 8:
-                    if (!e.currentTarget.value) {
-                        _this.removeEmail(_this.state.emails.length - 1);
-                    }
-                    break;
-                default:
-            }
-        };
-        _this.handleOnKeyup = function (e) {
-            switch (e.which) {
-                case 13:
-                case 9:
-                    _this.findEmailAddress(e.currentTarget.value, true);
-                    break;
-                default:
-            }
-        };
-        _this.handleOnChange = function (e) {
-            return _this.onChangeInputValue(e.currentTarget.value);
-        };
-        _this.handleOnBlur = function (e) {
-            _this.setState({ focused: false });
-            _this.findEmailAddress(e.currentTarget.value, true);
-        };
-        _this.handleOnFocus = function () {
-            return _this.setState({
-                focused: true,
-            });
-        };
-        _this.emailInputRef = React.createRef();
-        return _this;
-    }
-    ReactMultiEmail.getDerivedStateFromProps = function (nextProps, prevState) {
+var ReactMultiEmail = function (props) {
+    var _a = react_1.useState(false), focused = _a[0], setFocused = _a[1];
+    var _b = react_1.useState([]), emails = _b[0], setEmails = _b[1];
+    var _c = react_1.useState(''), inputValue = _c[0], setInputValue = _c[1];
+    var emailInputRef = react_1.createRef();
+    var getDerivedStateFromProps = function (nextProps, prevState) {
         if (prevState.propsEmails !== nextProps.emails) {
             return {
                 propsEmails: nextProps.emails || [],
@@ -142,22 +19,112 @@ var ReactMultiEmail = /** @class */ (function (_super) {
         }
         return null;
     };
-    ReactMultiEmail.prototype.render = function () {
-        var _this = this;
-        var _a = this.state, focused = _a.focused, emails = _a.emails, inputValue = _a.inputValue;
-        var _b = this.props, style = _b.style, getLabel = _b.getLabel, _c = _b.className, className = _c === void 0 ? '' : _c, noClass = _b.noClass, placeholder = _b.placeholder;
-        // removeEmail
-        return (React.createElement("div", { className: className + " " + (noClass ? '' : 'react-multi-email') + " " + (focused ? 'focused' : '') + " " + (inputValue === '' && emails.length === 0 ? 'empty' : ''), style: style, onClick: function () {
-                if (_this.emailInputRef.current) {
-                    _this.emailInputRef.current.focus();
+    var findEmailAddress = function (value, isEnter) {
+        var validateEmail = props.validateEmail;
+        var validEmails = [];
+        var findingInputValue = '';
+        var re = /[ ,;]/g;
+        var isEmail = validateEmail || isEmail_1.default;
+        var addEmails = function (email) {
+            var addingEmails = emails;
+            for (var i = 0, l = emails.length; i < l; i++) {
+                if (emails[i] === email) {
+                    return false;
                 }
-            } },
-            placeholder ? React.createElement("span", { "data-placeholder": true }, placeholder) : null,
-            emails.map(function (email, index) {
-                return getLabel(email, index, _this.removeEmail);
-            }),
-            React.createElement("input", { ref: this.emailInputRef, type: "text", value: inputValue, onFocus: this.handleOnFocus, onBlur: this.handleOnBlur, onChange: this.handleOnChange, onKeyDown: this.handleOnKeydown, onKeyUp: this.handleOnKeyup })));
+            }
+            validEmails.push(email);
+            return true;
+        };
+        if (value !== '') {
+            if (re.test(value)) {
+                var splitData = value.split(re).filter(function (n) {
+                    return n !== '' && n !== undefined && n !== null;
+                });
+                var setArr = new Set(splitData);
+                var arr = setArr.slice();
+                do {
+                    if (isEmail('' + arr[0])) {
+                        addEmails('' + arr.shift());
+                    }
+                    else {
+                        if (arr.length === 1) {
+                            /// 마지막 아이템이면 inputValue로 남겨두기
+                            findingInputValue = '' + arr.shift();
+                        }
+                        else {
+                            arr.shift();
+                        }
+                    }
+                } while (arr.length);
+            }
+            else {
+                if (isEnter) {
+                    if (isEmail(value)) {
+                        addEmails(value);
+                    }
+                    else {
+                        findingInputValue = value;
+                    }
+                }
+                else {
+                    findingInputValue = value;
+                }
+            }
+        }
+        setEmails(emails.concat(validEmails));
+        setInputValue(findingInputValue);
+        if (validEmails.length && props.onChange) {
+            props.onChange(emails.concat(validEmails));
+        }
     };
-    return ReactMultiEmail;
-}(React.Component));
+    var onChangeInputValue = function (value) {
+        findEmailAddress(value);
+    };
+    var removeEmail = function (index) {
+    };
+    var handleOnKeydown = function (e) {
+        switch (e.which) {
+            case 13:
+            case 9:
+                e.preventDefault();
+                break;
+            case 8:
+                if (!e.currentTarget.value) {
+                    removeEmail(emails.length - 1);
+                }
+                break;
+            default:
+        }
+    };
+    var handleOnKeyup = function (e) {
+        switch (e.which) {
+            case 13:
+            case 9:
+                findEmailAddress(e.currentTarget.value, true);
+                break;
+            default:
+        }
+    };
+    var handleOnChange = function (e) {
+        return onChangeInputValue(e.currentTarget.value);
+    };
+    var handleOnBlur = function (e) {
+        setFocused(false);
+        findEmailAddress(e.currentTarget.value, true);
+    };
+    var handleOnFocus = function () {
+        return setFocused(false);
+    };
+    var style = props.style, getLabel = props.getLabel, _d = props.className, className = _d === void 0 ? '' : _d, noClass = props.noClass, placeholder = props.placeholder;
+    return (React.createElement("div", { className: className + " " + (noClass ? '' : 'react-multi-email') + " " + (focused ? 'focused' : '') + " " + (inputValue === '' && emails.length === 0 ? 'empty' : ''), style: style, onClick: function () {
+            if (emailInputRef.current) {
+                emailInputRef.current.focus();
+            }
+        } },
+        placeholder ? React.createElement("span", { "data-placeholder": true }, placeholder) : null,
+        emails.map(function (email, index) {
+            return getLabel(email, index, removeEmail);
+        }),
+        React.createElement("input", { ref: emailInputRef, type: "text", value: inputValue, onFocus: handleOnFocus, onBlur: handleOnBlur, onChange: handleOnChange, onKeyDown: handleOnKeydown, onKeyUp: handleOnKeyup })));
+};
 exports.default = ReactMultiEmail;

--- a/package.json
+++ b/package.json
@@ -2,16 +2,15 @@
   "name": "react-multi-email",
   "version": "0.5.3",
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^16.4.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/history": "^4.7.0",
     "@types/jest": "^22.2.2",
     "@types/node": "^9.6.18",
-    "@types/react": "^16.3.14",
-    "@types/react-dom": "^16.0.5",
+    "@types/react": "^16.8.0",
+    "@types/react-dom": "^16.8.0",
     "@types/react-router": "^4.0.25",
     "@types/react-router-dom": "^4.2.6",
     "@types/react-syntax-highlighter": "0.0.5",
@@ -28,15 +27,14 @@
     "less-loader": "^4.1.0",
     "node-sass": "^4.8.3",
     "raw-loader": "^0.5.1",
-    "react": "^16.4.0",
+    "react": "^16.8.0",
     "react-app-rewire-css-modules": "github:codebandits/react-app-rewire-css-modules",
     "react-app-rewire-hot-loader": "^1.0.1",
     "react-app-rewire-less": "^2.1.2",
     "react-app-rewired": "^1.5.0",
-    "react-dom": "^16.4.0",
+    "react-dom": "^16.8.0",
     "react-ga": "^2.5.3",
     "react-github-button": "^0.1.11",
-    "react-hot-loader": "^4.2.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-scripts-ts": "2.15.1",
@@ -64,5 +62,8 @@
     "build:common": "cp ./src/react-multi-email/style.css ./dist/style.css && cp ./README.md ./dist/README.md",
     "build:es5": "rm -rf ./dist/commonjs && tsc src/react-multi-email/*.tsx --declaration --outDir dist/commonjs --jsx react --module commonjs --target es5 --moduleResolution node",
     "build:es6": "rm -rf ./dist/es6 && tsc src/react-multi-email/*.tsx --declaration --outDir dist/es6 --jsx react --module es6 --target es6 --moduleResolution node"
+  },
+  "dependencies": {
+    "react-hot-loader": "^4.12.18"
   }
 }

--- a/src/react-multi-email/ReactMultiEmail.tsx
+++ b/src/react-multi-email/ReactMultiEmail.tsx
@@ -25,15 +25,17 @@ const ReactMultiEmail: React.FC<IProps> = props => {
 
   const emailInputRef = createRef<HTMLInputElement>();
 
-  findEmailAddress = (value: string, isEnter?: boolean) => {
-    const { validateEmail } = this.props;
+  const findEmailAddress = (value: string, isEnter?: boolean) => {
+    const { validateEmail } = props;
     let validEmails: string[] = [];
-    let inputValue: string = '';
+    let findingInputValue: string = '';
     const re = /[ ,;]/g;
     const isEmail = validateEmail || isEmailFn;
 
     const addEmails = (email: string) => {
-      const emails: string[] = this.state.emails;
+      
+      const addingEmails: string[] = emails;
+
       for (let i = 0, l = emails.length; i < l; i++) {
         if (emails[i] === email) {
           return false;
@@ -48,7 +50,7 @@ const ReactMultiEmail: React.FC<IProps> = props => {
         let splitData = value.split(re).filter(n => {
           return n !== '' && n !== undefined && n !== null;
         });
-        
+
         const setArr = new Set(splitData);
         let arr = [...setArr];
 
@@ -58,7 +60,7 @@ const ReactMultiEmail: React.FC<IProps> = props => {
           } else {
             if (arr.length === 1) {
               /// 마지막 아이템이면 inputValue로 남겨두기
-              inputValue = '' + arr.shift();
+              findingInputValue = '' + arr.shift();
             } else {
               arr.shift();
             }
@@ -69,47 +71,37 @@ const ReactMultiEmail: React.FC<IProps> = props => {
           if (isEmail(value)) {
             addEmails(value);
           } else {
-            inputValue = value;
+            findingInputValue = value;
           }
         } else {
-          inputValue = value;
+          findingInputValue = value;
         }
       }
     }
 
-    this.setState({
-      emails: [...this.state.emails, ...validEmails],
-      inputValue: inputValue,
-    });
+    setEmails([...emails, ...validEmails]);
+    setInputValue(findingInputValue);
 
-    if (validEmails.length && this.props.onChange) {
-      this.props.onChange([...this.state.emails, ...validEmails]);
+    if (validEmails.length && props.onChange) {
+      props.onChange([...emails, ...validEmails]);
     }
   };
 
-  onChangeInputValue = (value: string) => {
-    this.findEmailAddress(value);
+  const onChangeInputValue = (value: string) => {
+    findEmailAddress(value);
   };
 
-  removeEmail = (index: number) => {
-    this.setState(
-      prevState => {
-        return {
-          emails: [
-            ...prevState.emails.slice(0, index),
-            ...prevState.emails.slice(index + 1),
-          ],
-        };
-      },
+  const removeEmail = (index: number) => {
+    setEmails([...emails.slice(0, index), ...emails.slice(index + 1)])
+      ,
       () => {
-        if (this.props.onChange) {
-          this.props.onChange(this.state.emails);
+        if (props.onChange) {
+          props.onChange(emails);
         }
-      },
-    );
+      }
   };
 
-  handleOnKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleOnKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     switch (e.which) {
       case 13:
       case 9:
@@ -117,71 +109,65 @@ const ReactMultiEmail: React.FC<IProps> = props => {
         break;
       case 8:
         if (!e.currentTarget.value) {
-          this.removeEmail(this.state.emails.length - 1);
+          removeEmail(emails.length - 1);
         }
         break;
       default:
     }
   };
 
-  handleOnKeyup = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleOnKeyup = (e: React.KeyboardEvent<HTMLInputElement>) => {
     switch (e.which) {
       case 13:
       case 9:
-        this.findEmailAddress(e.currentTarget.value, true);
+        findEmailAddress(e.currentTarget.value, true);
         break;
       default:
     }
   };
 
-  handleOnChange = (e: React.SyntheticEvent<HTMLInputElement>) =>
-    this.onChangeInputValue(e.currentTarget.value);
+  const handleOnChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    onChangeInputValue(e.currentTarget.value);
+  }
 
-  handleOnBlur = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    this.setState({ focused: false });
-    this.findEmailAddress(e.currentTarget.value, true);
+  const handleOnBlur = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    setFocused(false);
+    findEmailAddress(e.currentTarget.value, true);
   };
 
-  handleOnFocus = () =>
-    this.setState({
-      focused: true,
-    });
+  const handleOnFocus = () =>
+    setFocused(true);
 
-  render() {
-    const { focused, emails, inputValue } = this.state;
-    const { style, getLabel, className = '', noClass, placeholder } = this.props;
+  const { style, getLabel, className = '', noClass, placeholder } = props;
 
-    // removeEmail
-
-    return (
-      <div
-        className={`${className} ${noClass ? '' : 'react-multi-email'} ${
-          focused ? 'focused' : ''
+  return (
+    <div
+      className={`${className} ${noClass ? '' : 'react-multi-email'} ${
+        focused ? 'focused' : ''
         } ${inputValue === '' && emails.length === 0 ? 'empty' : ''}`}
-        style={style}
-        onClick={() => {
-          if (this.emailInputRef.current) {
-            this.emailInputRef.current.focus();
-          }
-        }}
-      >
-        {placeholder ? <span data-placeholder>{placeholder}</span> : null}
-        {emails.map((email: string, index: number) =>
-          getLabel(email, index, this.removeEmail),
-        )}
-        <input
-          ref={this.emailInputRef}
-          type="text"
-          value={inputValue}
-          onFocus={this.handleOnFocus}
-          onBlur={this.handleOnBlur}
-          onChange={this.handleOnChange}
-          onKeyDown={this.handleOnKeydown}
-          onKeyUp={this.handleOnKeyup}
-        />
-      </div>
-    );
-  }
+      style={style}
+      onClick={() => {
+        if (emailInputRef.current) {
+          emailInputRef.current.focus();
+        }
+      }}
+    >
+      {placeholder ? <span data-placeholder>{placeholder}</span> : null}
+      {emails.map((email: string, index: number) =>
+        getLabel(email, index, removeEmail),
+      )}
+      <input
+        ref={emailInputRef}
+        type="text"
+        value={inputValue}
+        onFocus={handleOnFocus}
+        onBlur={handleOnBlur}
+        onChange={handleOnChange}
+        onKeyDown={handleOnKeydown}
+        onKeyUp={handleOnKeyup}
+      />
+    </div>
+  );
 }
 
 export default ReactMultiEmail;

--- a/src/react-multi-email/ReactMultiEmail.tsx
+++ b/src/react-multi-email/ReactMultiEmail.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import isEmailFn from './isEmail';
 
-export interface IReactMultiEmailProps {
+interface IProps {
   emails?: string[];
   onChange?: (emails: string[]) => void;
   noClass?: boolean;

--- a/src/react-multi-email/ReactMultiEmail.tsx
+++ b/src/react-multi-email/ReactMultiEmail.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import isEmailFn from './isEmail';
+import { useState, createRef } from 'react';
 
 interface IProps {
   emails?: string[];
@@ -16,45 +17,13 @@ interface IProps {
   placeholder?: string | React.ReactNode;
 }
 
-export interface IReactMultiEmailState {
-  focused?: boolean;
-  propsEmails?: string[];
-  emails: string[];
-  inputValue?: string;
-}
+const ReactMultiEmail: React.FC<IProps> = props => {
 
-class ReactMultiEmail extends React.Component<
-  IReactMultiEmailProps,
-  IReactMultiEmailState
-> {
-  state = {
-    focused: false,
-    emails: [],
-    inputValue: '',
-  };
+  const [focused, setFocused] = useState<boolean>(false);
+  const [emails, setEmails] = useState<string[]>([]);
+  const [inputValue, setInputValue] = useState<string>('');
 
-  emailInputRef: React.RefObject<HTMLInputElement>;
-
-  static getDerivedStateFromProps(
-    nextProps: IReactMultiEmailProps,
-    prevState: IReactMultiEmailState,
-  ) {
-    if (prevState.propsEmails !== nextProps.emails) {
-      return {
-        propsEmails: nextProps.emails || [],
-        emails: nextProps.emails || [],
-        inputValue: '',
-        focused: false,
-      };
-    }
-    return null;
-  }
-
-  constructor(props: IReactMultiEmailProps) {
-    super(props);
-
-    this.emailInputRef = React.createRef();
-  }
+  const emailInputRef = createRef<HTMLInputElement>();
 
   findEmailAddress = (value: string, isEnter?: boolean) => {
     const { validateEmail } = this.props;


### PR DESCRIPTION
**1 - Update react, react-dom, react-hot-loader**
: Hooks only work with 16.8.0 and above. Therefore, react was updated to 16.8.0. 
react-dom has been updated accordingly.
react-hot-loader caused the 'invalid  hook call' bug.
This bug is gone when I updated react-hot-loader to latest version.

**2 - Refactoring to Hook codes**
: delete useless lifecycle function, and convert methods to function variables.
replace class-based state with state of hook version.