### PR TITLE
Expend input box to take the rest line space

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -44,6 +44,7 @@
 }
 
 .react-multi-email > input {
+  flex: 1;
   width: auto !important;
   outline: none !important;
   border: 0 none !important;

--- a/src/react-multi-email/style.css
+++ b/src/react-multi-email/style.css
@@ -44,6 +44,7 @@
 }
 
 .react-multi-email > input {
+  flex: 1;
   width: auto !important;
   outline: none !important;
   border: 0 none !important;


### PR DESCRIPTION
This extends the input field to take the rest of the line space so that it won't cut off on long email
![image](https://user-images.githubusercontent.com/1317139/75946104-fe576300-5f00-11ea-9895-de0fe2406e52.png)
